### PR TITLE
Instant Play and Vehicle Enhance

### DIFF
--- a/Game/PYTHON/base.py
+++ b/Game/PYTHON/base.py
@@ -38,9 +38,6 @@ SC_SCN = logic.getCurrentScene()
 SC_HUD = None
 SC_CAM = SC_SCN.active_camera
 
-print(SC_SCN.dbvt_culling)
-print(logic.globalDict.keys())
-
 if settings.checkWorldData() == False:
 	print("""\nPARTIALISM ERROR:\n\tIm going stop you right there...\n""")
 	SC_CAM.near = 0.1
@@ -416,7 +413,9 @@ class CoreObject:
 			OBJECT.reinstancePhysicsMesh()
 
 	def checkStability(self, align=False, offset=1.0):
-		return
+		if settings.config.DO_STABILITY == False:
+			return
+
 		obj = self.objects["Root"]
 
 		rayto = obj.worldPosition.copy()

--- a/Game/PYTHON/base.py
+++ b/Game/PYTHON/base.py
@@ -38,7 +38,9 @@ SC_SCN = logic.getCurrentScene()
 SC_HUD = None
 SC_CAM = SC_SCN.active_camera
 
+print(SC_SCN.dbvt_culling)
 print(logic.globalDict.keys())
+
 if settings.checkWorldData() == False:
 	print("""\nPARTIALISM ERROR:\n\tIm going stop you right there...\n""")
 	SC_CAM.near = 0.1
@@ -49,6 +51,10 @@ if settings.checkWorldData() == False:
 
 else:
 	CURRENT = logic.globalDict["CURRENT"]
+
+	if CURRENT["Level"] == None:
+		spawnerobj = logic.getCurrentController().owner
+		CURRENT["Level"] = spawnerobj.get("MAP", "None")+".blend"
 
 	CUR_LVL = CURRENT["Level"]+SC_SCN.name
 	CUR_PRF = CURRENT["Profile"]
@@ -157,14 +163,14 @@ def LOAD(owner):
 
 def RUN(cont):
 	owner = cont.owner
-	#try:
-	owner["Class"].RUN()
-	#except Exception as ex:
-	#	print("FATAL RUNTIME ERROR:", owner.name)
-	#	print("	", ex)
-	#	if owner.scene.active_camera in owner.childrenRecursive:
-	#		owner.scene.active_camera = SC_CAM
-	#	owner.endObject()
+	try:
+		owner["Class"].RUN()
+	except Exception as ex:
+		print("FATAL RUNTIME ERROR:", owner.name)
+		print("	", ex)
+		if owner.scene.active_camera in owner.childrenRecursive:
+			owner.scene.active_camera = SC_CAM
+		owner.endObject()
 
 class CoreObject:
 
@@ -410,6 +416,7 @@ class CoreObject:
 			OBJECT.reinstancePhysicsMesh()
 
 	def checkStability(self, align=False, offset=1.0):
+		return
 		obj = self.objects["Root"]
 
 		rayto = obj.worldPosition.copy()

--- a/Game/PYTHON/config.py
+++ b/Game/PYTHON/config.py
@@ -10,6 +10,8 @@ SCREENSHOT_PATH = "SCREENSHOTS"
 
 LIST_CHARACTERS = ["Actor", "Red", "Blue", "Purple"]
 
+DO_STABILITY = True #snap players to the surface above if no floor
+
 try:
 	from bge import app
 	upver = app.upbge_version

--- a/Game/PYTHON/launcher.py
+++ b/Game/PYTHON/launcher.py
@@ -31,18 +31,19 @@ import PYTHON.settings as settings
 import PYTHON.keymap as keymap
 
 
-if settings.checkWorldData() == False:
-#if "PROFILES" not in logic.globalDict:
-	logic.globalDict = {"PROFILES": {}}
+settings.checkWorldData(launcher=True)
 
-	logic.globalDict["PROFILES"]["__guest__"] = settings.GenerateProfileData()
+#if "PROFILES" not in logic.globalDict:
+#	logic.globalDict = {"PROFILES": {}}
+
+#	logic.globalDict["PROFILES"]["__guest__"] = settings.GenerateProfileData()
 
 #if "CURRENT" not in logic.globalDict:
-	logic.globalDict["BLENDS"] = logic.getBlendFileList("//MAPS")
-	logic.globalDict["DATA"] = {"GAMEPATH":logic.expandPath("//"), "Portal":{"Door":None, "Vehicle":None, "Zone":None, "Scene":None}}
-	logic.globalDict["CURRENT"] = {"Profile":"__guest__", "Level":None, "Player":None, "Scene":None}
-	logic.globalDict["GRAPHICS"] = settings.GenerateGraphicsData("LOW" in logic.getCurrentController().owner)
-	logic.globalDict["TRAVELING"] = False
+#	logic.globalDict["BLENDS"] = logic.getBlendFileList("//MAPS")
+#	logic.globalDict["DATA"] = {"GAMEPATH":logic.expandPath("//"), "Portal":{"Door":None, "Vehicle":None, "Zone":None, "Scene":None}}
+#	logic.globalDict["CURRENT"] = {"Profile":"__guest__", "Level":None, "Player":None, "Scene":None}
+#	logic.globalDict["GRAPHICS"] = settings.GenerateGraphicsData("LOW" in logic.getCurrentController().owner)
+#	logic.globalDict["TRAVELING"] = False
 
 settings.SETGFX(logic.globalDict["GRAPHICS"], launcher=True)
 

--- a/Game/PYTHON/launcher.py
+++ b/Game/PYTHON/launcher.py
@@ -33,18 +33,6 @@ import PYTHON.keymap as keymap
 
 settings.checkWorldData(launcher=True)
 
-#if "PROFILES" not in logic.globalDict:
-#	logic.globalDict = {"PROFILES": {}}
-
-#	logic.globalDict["PROFILES"]["__guest__"] = settings.GenerateProfileData()
-
-#if "CURRENT" not in logic.globalDict:
-#	logic.globalDict["BLENDS"] = logic.getBlendFileList("//MAPS")
-#	logic.globalDict["DATA"] = {"GAMEPATH":logic.expandPath("//"), "Portal":{"Door":None, "Vehicle":None, "Zone":None, "Scene":None}}
-#	logic.globalDict["CURRENT"] = {"Profile":"__guest__", "Level":None, "Player":None, "Scene":None}
-#	logic.globalDict["GRAPHICS"] = settings.GenerateGraphicsData("LOW" in logic.getCurrentController().owner)
-#	logic.globalDict["TRAVELING"] = False
-
 settings.SETGFX(logic.globalDict["GRAPHICS"], launcher=True)
 
 

--- a/Game/PYTHON/player.py
+++ b/Game/PYTHON/player.py
@@ -55,8 +55,6 @@ def SPAWN(cont):
 
 	if "CLIP" in owner:
 		base.LEVEL["CLIP"] = owner["CLIP"]
-	if "MAP" in owner and base.CURRENT["Level"] == None:
-		base.CURRENT["Level"] = owner["MAP"]+".blend"+base.SC_SCN.name
 
 	if base.CURRENT["Player"] == None:
 		player = owner.get("PLAYER", "Actor")

--- a/Game/PYTHON/player.py
+++ b/Game/PYTHON/player.py
@@ -28,14 +28,13 @@ import PYTHON.keymap as keymap
 import PYTHON.base as base
 import PYTHON.HUD as HUD
 
-if "CURRENT" in logic.globalDict:
-	for libblend in base.settings.config.LIBRARIES:
-		libblend = libblend+".blend"
-		logic.LibLoad( base.DATA["GAMEPATH"]+"CONTENT\\"+libblend, "Scene", load_actions=True, verbose=False, load_scripts=True)
+for libblend in base.settings.config.LIBRARIES:
+	libblend = libblend+".blend"
+	logic.LibLoad( base.DATA["GAMEPATH"]+"CONTENT\\"+libblend, "Scene", load_actions=True, verbose=False, load_scripts=True)
 
-	BLACK = base.SC_SCN.addObject("GFX_Black", base.SC_CAM, 0)
-	BLACK.setParent(base.SC_CAM)
-	BLACK.color = (0, 0, 0, 1)
+BLACK = base.SC_SCN.addObject("GFX_Black", base.SC_CAM, 0)
+BLACK.setParent(base.SC_CAM)
+BLACK.color = (0, 0, 0, 1)
 
 logic.PLAYERCLASS = None
 
@@ -46,7 +45,7 @@ def SPAWN(cont):
 	spawn = owner.get("SPAWN", True)
 	timer = owner.get("TIMER", 0+((base.settings.config.UPBGE_FIX == False)*30))
 
-	if "CURRENT" not in logic.globalDict or timer <= 30:
+	if timer <= 30:
 		owner["TIMER"] = timer+1
 		return
 
@@ -56,6 +55,8 @@ def SPAWN(cont):
 
 	if "CLIP" in owner:
 		base.LEVEL["CLIP"] = owner["CLIP"]
+	if "MAP" in owner and base.CURRENT["Level"] == None:
+		base.CURRENT["Level"] = owner["MAP"]+".blend"+base.SC_SCN.name
 
 	if base.CURRENT["Player"] == None:
 		player = owner.get("PLAYER", "Actor")
@@ -280,9 +281,9 @@ class CorePlayer(base.CoreAdvanced):
 		self.data["HUD"]["Target"] = None
 		self.data["HUD"]["Text"] = ""
 
-		self.doUpdate(False)
 
 		if self.objects["Root"] != None:
+			self.doUpdate(False)
 			self.doCrouch(False)
 			self.objects["Character"].removeParent()
 			self.objects["Root"].endObject()

--- a/Game/PYTHON/player.py
+++ b/Game/PYTHON/player.py
@@ -279,9 +279,9 @@ class CorePlayer(base.CoreAdvanced):
 		self.data["HUD"]["Target"] = None
 		self.data["HUD"]["Text"] = ""
 
+		self.doUpdate(False)
 
 		if self.objects["Root"] != None:
-			self.doUpdate(False)
 			self.doCrouch(False)
 			self.objects["Character"].removeParent()
 			self.objects["Root"].endObject()

--- a/Game/PYTHON/settings.py
+++ b/Game/PYTHON/settings.py
@@ -233,6 +233,7 @@ def SCREENSHOT():
 			num = 0
 		else:
 			num = dict["Value"]
+		screen["Count"] = num
 
 	if screen["Trigger"] == "Launcher":
 		curlvl = "Launcher"

--- a/Game/PYTHON/settings.py
+++ b/Game/PYTHON/settings.py
@@ -81,30 +81,44 @@ def openWorldBlend(map):
 	logic.startGame(gd["DATA"]["GAMEPATH"]+blend)
 
 
-def checkWorldData(path=None):
+def checkWorldData(launcher=False):
+	path = logic.expandPath("//")
+	if launcher == False:
+		path = path+"..\\"
+	print(path)
+
 	if config.UPBGE_FIX == True:
-		if path == None:
-			path = logic.expandPath("//")
-		print(path)
 		dict = LoadJSON(path+"gd_dump")
-		if dict == None:
-			dict = LoadJSON(path+"..\\gd_dump")
+		#if dict == None:
+		#	dict = LoadJSON(path+"..\\gd_dump")
 		if dict != None:
 			if dict["TRAVELING"] == True:
 				logic.globalDict = dict
 				logic.globalDict["TRAVELING"] = False
 				SaveJSON(logic.globalDict["DATA"]["GAMEPATH"]+"gd_dump", {"TRAVELING":False}, "\t")
 
-	if "CURRENT" in logic.globalDict:
-		return True
+	if "CURRENT" not in logic.globalDict:
+		generateGlobalDict(path)
+	return True
 
-	return False
 
+def generateGlobalDict(path):
+	logic.globalDict = {"PROFILES": {}}
+
+	logic.globalDict["PROFILES"]["__guest__"] = GenerateProfileData()
+
+	logic.globalDict["BLENDS"] = logic.getBlendFileList(path+"MAPS")
+	logic.globalDict["DATA"] = {"GAMEPATH":path, "Portal":{"Door":None, "Vehicle":None, "Zone":None, "Scene":None}}
+	logic.globalDict["CURRENT"] = {"Profile":"__guest__", "Level":None, "Player":None, "Scene":None}
+	logic.globalDict["GRAPHICS"] = GenerateGraphicsData()
+	logic.globalDict["TRAVELING"] = False
+
+	logic.globalDict["SCREENSHOT"] = {"Trigger":False, "Count":None}
 
 def GenerateProfileData():
 	return {"LVLData":{}, "PLRData":{}, "Last":{}, "Settings":{}}
 
-def GenerateGraphicsData(low=False):
+def GenerateGraphicsData():
 	data = LoadJSON(logic.globalDict["DATA"]["GAMEPATH"]+"Graphics.cfg")
 
 	if data == None:
@@ -205,22 +219,22 @@ def SETGFX(graphics=None, launcher=False, save=False):
 
 
 def triggerPrintScreen(mode=True):
-	logic.globalDict["SCREENSHOT"]["Trigger"] = mode
+	if "SCREENSHOT" in globalDict:
+		logic.globalDict["SCREENSHOT"]["Trigger"] = mode
 
 
 def SCREENSHOT():
 	path = ospath.normpath(logic.globalDict["DATA"]["GAMEPATH"]+config.SCREENSHOT_PATH)+"\\"
 
-	if "SCREENSHOT" not in logic.globalDict:
+	screen = logic.globalDict["SCREENSHOT"]
+	curlvl = str(logic.globalDict["CURRENT"]["Level"]).replace(".blend", "")
+
+	if screen["Count"] == None:
 		dict = LoadJSON(path+"marker.json")
 		if dict == None:
 			num = 0
 		else:
 			num = dict["Value"]
-		logic.globalDict["SCREENSHOT"] = {"Trigger":False, "Count":num}
-
-	screen = logic.globalDict["SCREENSHOT"]
-	curlvl = str(logic.globalDict["CURRENT"]["Level"]).replace(".blend", "")
 
 	if screen["Trigger"] == "Launcher":
 		curlvl = "Launcher"

--- a/Game/PYTHON/settings.py
+++ b/Game/PYTHON/settings.py
@@ -85,12 +85,11 @@ def checkWorldData(launcher=False):
 	path = logic.expandPath("//")
 	if launcher == False:
 		path = path+"..\\"
+	path = ospath.normpath(path)+"\\"
 	print(path)
 
 	if config.UPBGE_FIX == True:
 		dict = LoadJSON(path+"gd_dump")
-		#if dict == None:
-		#	dict = LoadJSON(path+"..\\gd_dump")
 		if dict != None:
 			if dict["TRAVELING"] == True:
 				logic.globalDict = dict
@@ -219,8 +218,7 @@ def SETGFX(graphics=None, launcher=False, save=False):
 
 
 def triggerPrintScreen(mode=True):
-	if "SCREENSHOT" in globalDict:
-		logic.globalDict["SCREENSHOT"]["Trigger"] = mode
+	logic.globalDict["SCREENSHOT"]["Trigger"] = mode
 
 
 def SCREENSHOT():

--- a/Game/PYTHON/vehicle.py
+++ b/Game/PYTHON/vehicle.py
@@ -612,21 +612,29 @@ class CoreAircraft(CoreVehicle):
 	AERO = {"POWER":1000, "HOVER":0, "LIFT":0.1, "TAIL":10}
 	HUDLAYOUT = LayoutAircraft
 
+	def defaultData(self):
+		self.lift = 0
+
+		dict = {}
+		dict["POWER"] = 0
+		dict["HOVER"] = [0,0]
+		dict["HUD"] = {"Power":0, "Lift":0}
+
+		return dict
+
 	def airDrag(self):
 
-		#dampLin = 0.0
-		#dampRot = (self.linV[1]*0.002)+0.4
+		dampLin = 0.0
+		dampRot = (self.linV[1]*0.002)+0.4
 
-		#if dampRot >= 0.7:
-		#	dampRot = 0.7
+		if dampRot >= 0.7:
+			dampRot = 0.7
 
-		#self.objects["Root"].setDamping(dampLin, dampRot)
+		self.objects["Root"].setDamping(dampLin, dampRot)
 
-		ABS_Y = abs(self.linV[1])
-
-		DRAG_X = self.linV[0]*ABS_Y*self.AERO["DRAG"][0]
-		DRAG_Y = self.linV[1]*ABS_Y*self.AERO["DRAG"][1]
-		DRAG_Z = self.linV[2]*ABS_Y*self.AERO["DRAG"][2]
+		DRAG_X = self.linV[0]*abs(self.linV[0])*1
+		DRAG_Y = self.linV[1]*abs(self.linV[1])*1
+		DRAG_Z = self.linV[2]*abs(self.linV[2])*1
 
 		self.objects["Root"].applyForce((-DRAG_X, -DRAG_Y, -DRAG_Z), True)
 
@@ -655,15 +663,21 @@ class CoreAircraft(CoreVehicle):
 
 		force = self.motion["Force"]
 		torque = self.motion["Torque"]
-		grav = owner.scene.gravity[2]
-		mass = owner.mass/100
+		grav = -owner.scene.gravity[2]
+		mass = owner.mass
 
 		self.data["POWER"] += force[1]*(self.AERO["POWER"]/100)
 		if self.data["POWER"] > self.AERO["POWER"]:
 			self.data["POWER"] = self.AERO["POWER"]
 
-		if self.data["POWER"] < 0:
-			self.data["POWER"] = 0
+		maxR = self.AERO["POWER"]/4
+		if self.data["POWER"] < -maxR:
+			self.data["POWER"] = -maxR
+		elif self.data["POWER"] < 0:
+			if force[1] > -0.1:
+				self.data["POWER"] += (self.AERO["POWER"]/100)
+				if self.data["POWER"] > 0:
+					self.data["POWER"] = 0
 
 		self.data["HOVER"][0] += force[2]*20
 		if self.data["HOVER"][0] > 1000 or self.data["HOVER"][1] > 0:

--- a/Game/PYTHON/vehicle.py
+++ b/Game/PYTHON/vehicle.py
@@ -120,10 +120,10 @@ class CoreVehicle(base.CoreAdvanced):
 			owner.setLinearVelocity(self.data["LINVEL"], True)
 			owner.setAngularVelocity(self.data["ANGVEL"], True)
 
-			self.ST_Active_Set()
 			base.DATA["Portal"]["Door"] = None
 			base.DATA["Portal"]["Zone"] = None
 			base.DATA["Portal"]["Vehicle"] = None
+			self.ST_Active_Set()
 
 	def doUpdate(self, world=True):
 		owner = self.objects["Root"]


### PR DESCRIPTION
Map blend files now immediately launch into that map.

**Issue:** Using a world door or opening launcher will erase the starting map data. After that, save and load should return to normal. This DOES NOT effect launching from launcher or EXE.  

**Solution:** Add a game string property "MAP" to the `Spawn.Player` object and set it equal to the blend file name. Ex: `MAPS\Level 00.blend` should set the property to "Level 00".